### PR TITLE
XirSys 0.3

### DIFF
--- a/Classes/Networking/XSNetworkRequest.m
+++ b/Classes/Networking/XSNetworkRequest.m
@@ -104,7 +104,9 @@ NSString * const XSErrorDomain = @"com.xirsys.error";
     NSError *error = nil;
     
     if (statusCode >= 300) {
-        error = [NSError errorWithDomain:XSErrorDomain code:statusCode userInfo:response];
+        NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [response objectForKey:@"e"], @"status": @(statusCode) };
+        
+        error = [NSError errorWithDomain:XSErrorDomain code:statusCode userInfo:userInfo];
     }
     
     return error;

--- a/Classes/Networking/XSNetworkRequest.m
+++ b/Classes/Networking/XSNetworkRequest.m
@@ -9,6 +9,7 @@
 #import "XSNetworkRequest.h"
 
 NSString * const XSBaseURL = @"https://api.xirsys.com/";
+NSString * const XSErrorDomain = @"com.xirsys.error";
 
 @interface XSNetworkRequest ()
 
@@ -46,8 +47,15 @@ NSString * const XSBaseURL = @"https://api.xirsys.com/";
     
     NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (completion) {
-            id response = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil];
-            completion(response, error);
+            NSDictionary *response = (NSDictionary *)[NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil];
+            NSError *error = [self errorFromResponse:response];
+            
+            if (error) {
+                completion(nil, error);
+            }
+            else {
+                completion(response, nil);
+            }
         }
     }];
     
@@ -88,6 +96,18 @@ NSString * const XSBaseURL = @"https://api.xirsys.com/";
     [mutableParameters addEntriesFromDictionary:self.credentials];
     
     return [mutableParameters copy];
+}
+
+- (NSError *)errorFromResponse:(NSDictionary *)response
+{
+    NSUInteger statusCode = [[response objectForKey:@"s"] unsignedIntegerValue];
+    NSError *error = nil;
+    
+    if (statusCode >= 300) {
+        error = [NSError errorWithDomain:XSErrorDomain code:statusCode userInfo:response];
+    }
+    
+    return error;
 }
 
 @end

--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -1,3 +1,9 @@
+plugin 'cocoapods-keys', {
+  project: 'Tests',
+  keys: [
+    'XirSysUsername',
+    'XirSysSecretKey'
+  ]}
 
 target 'XirSys', :exclusive => true do
   pod 'XirSys', :path => "../"

--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -2,6 +2,6 @@
 target 'XirSys', :exclusive => true do
   pod 'XirSys', :path => "../"
 
-  pod 'Specta', '~> 0.2.1'
+  pod 'Specta'
   pod 'Expecta'
 end

--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -1,5 +1,6 @@
 plugin 'cocoapods-keys', {
   project: 'Tests',
+  target: 'XirSys',
   keys: [
     'XirSysUsername',
     'XirSysSecretKey'

--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -1,5 +1,5 @@
 plugin 'cocoapods-keys', {
-  project: 'Tests',
+  project: 'XirSys',
   target: 'XirSys',
   keys: [
     'XirSysUsername',

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - Expecta (1.0.0)
-  - Specta (0.2.1)
-  - XirSys (0.2)
+  - Specta (1.0.1)
+  - XirSys (0.3)
 
 DEPENDENCIES:
   - Expecta
-  - Specta (~> 0.2.1)
+  - Specta
   - XirSys (from `../`)
 
 EXTERNAL SOURCES:
@@ -14,7 +14,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Expecta: 32604574add2c46a36f8d2f716b6c5736eb75024
-  Specta: 15a276a6343867b426d5ed135d5aa4d04123a573
-  XirSys: b6184f2667e4b12fa92348f7a1987757087e5cfe
+  Specta: 097be314a75de103703a3bf9a529dc1a398509d7
+  XirSys: 542a6e665b875fd01d519a09a11455b9fd42a556
 
 COCOAPODS: 0.37.1

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -1,19 +1,24 @@
 PODS:
   - Expecta (1.0.0)
+  - Keys (1.0.0)
   - Specta (1.0.1)
   - XirSys (0.3)
 
 DEPENDENCIES:
   - Expecta
+  - Keys (from `Pods/CocoaPodsKeys/`)
   - Specta
   - XirSys (from `../`)
 
 EXTERNAL SOURCES:
+  Keys:
+    :path: Pods/CocoaPodsKeys/
   XirSys:
     :path: "../"
 
 SPEC CHECKSUMS:
   Expecta: 32604574add2c46a36f8d2f716b6c5736eb75024
+  Keys: 7d2ff6ff42f6903358267ce56e9392f83c31acfe
   Specta: 097be314a75de103703a3bf9a529dc1a398509d7
   XirSys: 542a6e665b875fd01d519a09a11455b9fd42a556
 

--- a/Tests/Tests/XSClientSpec.m
+++ b/Tests/Tests/XSClientSpec.m
@@ -9,11 +9,11 @@
 #import <Specta/Specta.h>
 #import <Expecta/Expecta.h>
 #import <XirSys/XSClient.h>
-#import <Keys/TestsKeys.h>
+#import <Keys/XirSysKeys.h>
 
 SpecBegin(XSClient)
 
-TestsKeys *keys = [[TestsKeys alloc] init];
+XirSysKeys *keys = [[XirSysKeys alloc] init];
 XSClient *client = [[XSClient alloc] initWithUsername:keys.xirSysUsername secretKey:keys.xirSysSecretKey];
 
 describe(@"initialization", ^{

--- a/Tests/Tests/XSClientSpec.m
+++ b/Tests/Tests/XSClientSpec.m
@@ -9,50 +9,88 @@
 #import <Specta/Specta.h>
 #import <Expecta/Expecta.h>
 #import <XirSys/XSClient.h>
+#import <Keys/TestsKeys.h>
 
 SpecBegin(XSClient)
 
+TestsKeys *keys = [[TestsKeys alloc] init];
+XSClient *client = [[XSClient alloc] initWithUsername:keys.xirSysUsername secretKey:keys.xirSysSecretKey];
+
 describe(@"initialization", ^{
     it(@"is created with the correct properties", ^{
-        XSClient *client = [[XSClient alloc] initWithUsername:@"samsymons" secretKey:@"secretkey"];
-        
-        expect(client.username).to.equal(@"samsymons");
-        expect(client.secretKey).to.equal(@"secretkey");
+        expect(client.username).to.equal(keys.xirSysUsername);
+        expect(client.secretKey).to.equal(keys.xirSysSecretKey);
     });
 });
 
 describe(@"getIceServersForDomain:application:room:secure:completion:", ^{
-    XSClient *client = [[XSClient alloc] initWithUsername:@"samsymons" secretKey:@"secretkey"];
-    
-    fit(@"lists the XirSys WebSocket servers", ^AsyncBlock {
-        [client getIceServersForDomain:@"perch.co" application:@"default" room:@"default" username:@"samsymons" secure:NO completion:^(NSArray *servers, NSError *error) {
-            NSLog(@"Servers: %@", servers);
-            expect(error).to.beNil();
-            done();
-        }];
+    it(@"lists the XirSys WebSocket servers", ^{
+        waitUntil(^(DoneCallback done) {
+            [client getIceServersForDomain:@"perch.co" application:@"default" room:@"default" username:@"samsymons" secure:NO completion:^(NSArray *servers, NSError *error) {                
+                expect(error).to.beNil();
+                done();
+            }];
+        });
     });
-});
-
-describe(@"listDomainsWithCompletion:", ^{
-    XSClient *client = [[XSClient alloc] initWithUsername:@"samsymons" secretKey:@"secretkey"];
     
-    it(@"lists the XirSys WebSocket servers", ^AsyncBlock {
-        [client listWebSocketServersWithCompletion:^(NSDictionary *servers, NSError *error) {
-            expect(error).to.beNil();
-            done();
-        }];
-    });
-});
-
-describe(@"listDomainsWithCompletion:", ^{
-    XSClient *client = [[XSClient alloc] initWithUsername:@"samsymons" secretKey:@"secretkey"];
-    
-    it(@"lists a user's domains", ^AsyncBlock {
-        [client listDomainsWithCompletion:^(NSArray *domains, NSError *error) {
-            expect(domains).to.contain(@"perch.co");
+    it(@"returns an error when given invalid credentials", ^{
+        waitUntil(^(DoneCallback done) {
+            XSClient *badClient = [[XSClient alloc] initWithUsername:@"username" secretKey:@"password"];
             
-            done();
-        }];
+            [badClient getIceServersForDomain:@"perch.co" application:@"default" room:@"default" username:@"samsymons" secure:NO completion:^(NSArray *servers, NSError *error) {
+                expect(servers.count).to.equal(0);
+                expect(error).toNot.beNil();
+                
+                done();
+            }];
+        });
+    });
+});
+
+describe(@"listDomainsWithCompletion:", ^{
+    it(@"lists the XirSys WebSocket servers", ^{
+        waitUntil(^(DoneCallback done) {
+            [client listWebSocketServersWithCompletion:^(NSDictionary *servers, NSError *error) {
+                expect(error).to.beNil();
+                done();
+            }];
+        });
+    });
+    
+    it(@"does not return an error when given invalid credentials", ^{
+        waitUntil(^(DoneCallback done) {
+            XSClient *badClient = [[XSClient alloc] initWithUsername:@"username" secretKey:@"password"];
+            
+            [badClient listWebSocketServersWithCompletion:^(NSDictionary *servers, NSError *error) {
+                expect(error).to.beNil();
+                done();
+            }];
+        });
+    });
+});
+
+describe(@"listDomainsWithCompletion:", ^{
+    it(@"lists a user's domains", ^{
+        waitUntil(^(DoneCallback done) {
+            [client listDomainsWithCompletion:^(NSArray *domains, NSError *error) {
+                expect(domains).to.contain(@"perch.co");
+                
+                done();
+            }];
+        });
+    });
+    
+    it(@"returns an error when given invalid credentials", ^{
+        waitUntil(^(DoneCallback done) {
+            XSClient *badClient = [[XSClient alloc] initWithUsername:@"username" secretKey:@"password"];
+            
+            [badClient listDomainsWithCompletion:^(NSArray *domains, NSError *error) {
+                expect(domains).to.beNil();
+                expect(error).toNot.beNil();
+                
+                done();
+            }];
+        });
     });
 });
 

--- a/Tests/Tests/XSClientSpec.m
+++ b/Tests/Tests/XSClientSpec.m
@@ -26,7 +26,7 @@ describe(@"initialization", ^{
 describe(@"getIceServersForDomain:application:room:secure:completion:", ^{
     it(@"lists the XirSys WebSocket servers", ^{
         waitUntil(^(DoneCallback done) {
-            [client getIceServersForDomain:@"perch.co" application:@"default" room:@"default" username:@"samsymons" secure:NO completion:^(NSArray *servers, NSError *error) {                
+            [client getIceServersForDomain:@"perch.co" application:@"default" room:@"default" username:keys.xirSysUsername secure:NO completion:^(NSArray *servers, NSError *error) {
                 expect(error).to.beNil();
                 done();
             }];
@@ -37,7 +37,7 @@ describe(@"getIceServersForDomain:application:room:secure:completion:", ^{
         waitUntil(^(DoneCallback done) {
             XSClient *badClient = [[XSClient alloc] initWithUsername:@"username" secretKey:@"password"];
             
-            [badClient getIceServersForDomain:@"perch.co" application:@"default" room:@"default" username:@"samsymons" secure:NO completion:^(NSArray *servers, NSError *error) {
+            [badClient getIceServersForDomain:@"perch.co" application:@"default" room:@"default" username:@"username" secure:NO completion:^(NSArray *servers, NSError *error) {
                 expect(servers.count).to.equal(0);
                 expect(error).toNot.beNil();
                 

--- a/Tests/Tests/XSNetworkRequestSpec.m
+++ b/Tests/Tests/XSNetworkRequestSpec.m
@@ -7,15 +7,19 @@
 //
 
 #import <XirSys/Networking/XSNetworkRequest.h>
+#import <Specta/Specta.h>
+#import <Keys/TestsKeys.h>
 
 SpecBegin(XSNetworkRequest)
 
+TestsKeys *keys = [[TestsKeys alloc] init];
+
 describe(@"initialization", ^{
     it(@"is created with the correct properties", ^{
-        XSNetworkRequest *request = [[XSNetworkRequest alloc] initWithUsername:@"samsymons" secretKey:@"secretkey"];
+        XSNetworkRequest *request = [[XSNetworkRequest alloc] initWithUsername:keys.xirSysUsername secretKey:keys.xirSysSecretKey];
         
-        expect(request.username).to.equal(@"samsymons");
-        expect(request.secretKey).to.equal(@"secretkey");
+        expect(request.username).to.equal(keys.xirSysUsername);
+        expect(request.secretKey).to.equal(keys.xirSysSecretKey);
     });
 });
 

--- a/Tests/Tests/XSNetworkRequestSpec.m
+++ b/Tests/Tests/XSNetworkRequestSpec.m
@@ -8,11 +8,11 @@
 
 #import <XirSys/Networking/XSNetworkRequest.h>
 #import <Specta/Specta.h>
-#import <Keys/TestsKeys.h>
+#import <Keys/XirSysKeys.h>
 
 SpecBegin(XSNetworkRequest)
 
-TestsKeys *keys = [[TestsKeys alloc] init];
+XirSysKeys *keys = [[XirSysKeys alloc] init];
 
 describe(@"initialization", ^{
     it(@"is created with the correct properties", ^{

--- a/Tests/XirSys.xcodeproj/project.pbxproj
+++ b/Tests/XirSys.xcodeproj/project.pbxproj
@@ -251,6 +251,7 @@
 /* Begin XCBuildConfiguration section */
 		6003F5BD195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 57C9664BD5FDE052BEECE36A /* Pods-XirSys.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -290,6 +291,7 @@
 		};
 		6003F5BE195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C2B9E030E616D93353ED03DE /* Pods-XirSys.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";

--- a/Tests/XirSys.xcodeproj/project.pbxproj
+++ b/Tests/XirSys.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5B8195388D20070C39A /* InfoPlist.strings */; };
 		7C54BC5770014EFBA48CF1CF /* libPods-XirSys.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C81F4763C2CB438BB2142A7F /* libPods-XirSys.a */; };
+		D0BAD2FA3316EECF35954D4F /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F7B7752CA76C57F32917B794 /* libPods.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 		C81F4763C2CB438BB2142A7F /* libPods-XirSys.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-XirSys.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9C1A536F2AC4FE2A1D60536 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		EFB5B4CA84D64084895512C5 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		F7B7752CA76C57F32917B794 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -45,6 +47,7 @@
 				6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F5B1195388D20070C39A /* Foundation.framework in Frameworks */,
 				7C54BC5770014EFBA48CF1CF /* libPods-XirSys.a in Frameworks */,
+				D0BAD2FA3316EECF35954D4F /* libPods.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -79,6 +82,7 @@
 				6003F591195388D20070C39A /* UIKit.framework */,
 				6003F5AF195388D20070C39A /* XCTest.framework */,
 				C81F4763C2CB438BB2142A7F /* libPods-XirSys.a */,
+				F7B7752CA76C57F32917B794 /* libPods.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/Tests/XirSys.xcodeproj/xcshareddata/xcschemes/XirSys.xcscheme
+++ b/Tests/XirSys.xcodeproj/xcshareddata/xcschemes/XirSys.xcscheme
@@ -58,7 +58,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "6003F5AD195388D20070C39A"
@@ -76,7 +77,8 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "6003F5AD195388D20070C39A"

--- a/Tests/XirSys.xcworkspace/contents.xcworkspacedata
+++ b/Tests/XirSys.xcworkspace/contents.xcworkspacedata
@@ -1,1 +1,10 @@
-<?xml version='1.0' encoding='UTF-8'?><Workspace version='1.0'><FileRef location='group:XirSys.xcodeproj'/><FileRef location='group:Pods/Pods.xcodeproj'/></Workspace>
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:XirSys.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/XirSys.podspec
+++ b/XirSys.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "XirSys"
-  s.version          = "0.2"
+  s.version          = "0.3"
   s.summary          = "An Objective-C client for the XirSys API."
   s.homepage         = "https://github.com/samsymons/XirSys"
   s.license          = 'MIT'


### PR DESCRIPTION
I've made some changes to the way we handle requests, and how unit tests are performed. The highlights:

* Added very basic error handling at the request level, to catch errors as they are returned by XirSys (in the future it would be better to add explicit error codes and such, instead of just packing that into an NSError directly)
* [cocoapods-keys](https://github.com/orta/cocoapods-keys) has been added to the project, to allow for realistic testing of API endpoint
* Updated Specta and Expecta, and added unit tests for the new error handling behaviour
* Increased the version to 0.3

CocoaPods will ask you for your credentials after you run `pod install`, allowing you to run the unit tests locally.

This would fix issue #3.