### PR TITLE
XirSys v2 API Support

### DIFF
--- a/Classes/Networking/XSNetworkRequest.h
+++ b/Classes/Networking/XSNetworkRequest.h
@@ -24,4 +24,6 @@ typedef void(^XSNetworkCompletion)(id response, NSError *error);
  */
 - (NSURLSessionDataTask *)postPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(XSNetworkCompletion)completion;
 
+- (NSURLSessionDataTask *)getPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(XSNetworkCompletion)completion;
+
 @end

--- a/Classes/Networking/XSNetworkRequest.m
+++ b/Classes/Networking/XSNetworkRequest.m
@@ -8,7 +8,7 @@
 
 #import "XSNetworkRequest.h"
 
-NSString * const XSBaseURL = @"https://api.xirsys.com/";
+NSString * const XSBaseURL = @"https://service.xirsys.com/";
 NSString * const XSErrorDomain = @"com.xirsys.error";
 
 @interface XSNetworkRequest ()

--- a/Classes/Networking/XSNetworkRequest.m
+++ b/Classes/Networking/XSNetworkRequest.m
@@ -39,22 +39,34 @@ NSString * const XSBaseURL = @"https://api.xirsys.com/";
 
 - (NSURLSessionDataTask *)postPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(XSNetworkCompletion)completion
 {
+    return [self method:@"POST" path:path parameters:parameters completion:completion];
+}
+
+- (NSURLSessionDataTask *)getPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(XSNetworkCompletion)completion
+{
+    return [self method:@"GET" path:path parameters:parameters completion:completion];
+}
+
+#pragma mark - Private
+
+- (NSURLSessionDataTask *)method:(NSString *)method path:(NSString *)path parameters:(NSDictionary *)parameters completion:(XSNetworkCompletion)completion
+{
     NSParameterAssert(path);
-    
+
     NSDictionary *requestParameters = [self parametersByMergingCredentials:parameters];
-    NSURLRequest *request = [self requestWithPath:path parameters:requestParameters method:@"POST"];
-    
+    NSURLRequest *request = [self requestWithPath:path parameters:requestParameters method:method];
+
     NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (completion) {
             id response = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil];
             completion(response, error);
         }
     }];
-    
+
+    task.priority = NSURLSessionTaskPriorityHigh;
+
     return task;
 }
-
-#pragma mark - Private
 
 - (NSURLRequest *)requestWithPath:(NSString *)path parameters:(NSDictionary *)parameters method:(NSString *)method
 {

--- a/Classes/XSClient.h
+++ b/Classes/XSClient.h
@@ -14,8 +14,6 @@ typedef void(^XSArrayCompletion)(NSArray *collection, NSError *error);
 
 typedef NS_ENUM(NSUInteger, XSSignalingType) {
     XSSignalingTypePeer,
-    XSSignalingTypePublish,
-    XSSignalingTypeSubscribe
 };
 
 @interface XSClient : NSObject
@@ -34,19 +32,16 @@ typedef NS_ENUM(NSUInteger, XSSignalingType) {
 
 - (NSURLSessionDataTask *)getTokenForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room username:(NSString *)username secure:(BOOL)secure completion:(XSObjectCompletion)completion;
 
-- (NSURLSessionDataTask *)getTokenForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room username:(NSString *)username secure:(BOOL)secure signalType:(XSSignalingType)type completion:(XSObjectCompletion)completion;
-
 /**
  List all ICE servers for a given domain.
  */
 - (NSURLSessionDataTask *)getIceServersForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room username:(NSString *)username secure:(BOOL)secure completion:(XSArrayCompletion)completion;
 
-- (NSURLSessionDataTask *)getIceServersForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room username:(NSString *)username secure:(BOOL)secure timeout:(NSTimeInterval)timeout completion:(XSArrayCompletion)completion;
-
 /**
- Lists the subscription URL(s) for published streams in a given room.
+ List all ICE servers for a given domain.
+ @timeout Timeout interval for the ICE Credentials. Maximum of 30 minutes.
  */
-- (NSURLSessionDataTask *)getSubscriptionsForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room completion:(XSObjectCompletion)completion;
+- (NSURLSessionDataTask *)getIceServersForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room username:(NSString *)username secure:(BOOL)secure timeout:(NSTimeInterval)timeout completion:(XSArrayCompletion)completion;
 
 /**
  Lists all of the WebSocket servers provided by XirSys.

--- a/Classes/XSClient.h
+++ b/Classes/XSClient.h
@@ -12,6 +12,12 @@ typedef void(^XSCompletion)(NSError *error);
 typedef void(^XSObjectCompletion)(id object, NSError *error);
 typedef void(^XSArrayCompletion)(NSArray *collection, NSError *error);
 
+typedef NS_ENUM(NSUInteger, XSSignalingType) {
+    XSSignalingTypePeer,
+    XSSignalingTypePublish,
+    XSSignalingTypeSubscribe
+};
+
 @interface XSClient : NSObject
 
 /**
@@ -28,10 +34,19 @@ typedef void(^XSArrayCompletion)(NSArray *collection, NSError *error);
 
 - (NSURLSessionDataTask *)getTokenForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room username:(NSString *)username secure:(BOOL)secure completion:(XSObjectCompletion)completion;
 
+- (NSURLSessionDataTask *)getTokenForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room username:(NSString *)username secure:(BOOL)secure signalType:(XSSignalingType)type completion:(XSObjectCompletion)completion;
+
 /**
  List all ICE servers for a given domain.
  */
 - (NSURLSessionDataTask *)getIceServersForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room username:(NSString *)username secure:(BOOL)secure completion:(XSArrayCompletion)completion;
+
+- (NSURLSessionDataTask *)getIceServersForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room username:(NSString *)username secure:(BOOL)secure timeout:(NSTimeInterval)timeout completion:(XSArrayCompletion)completion;
+
+/**
+ Lists the subscription URL(s) for published streams in a given room.
+ */
+- (NSURLSessionDataTask *)getSubscriptionsForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room completion:(XSObjectCompletion)completion;
 
 /**
  Lists all of the WebSocket servers provided by XirSys.
@@ -42,6 +57,11 @@ typedef void(^XSArrayCompletion)(NSArray *collection, NSError *error);
  Lists all of the domains available to your account.
  */
 - (NSURLSessionDataTask *)listDomainsWithCompletion:(XSArrayCompletion)completion;
+
+/**
+ Lists all of the applications available to in a given domain.
+ */
+- (NSURLSessionDataTask *)listApplicationsWithDomain:(NSString *)domain completion:(XSArrayCompletion)completion;
 
 /**
  Creates a new domain in an account.
@@ -56,6 +76,6 @@ typedef void(^XSArrayCompletion)(NSArray *collection, NSError *error);
 /**
  Creates a new room in an application.
  */
-- (NSURLSessionDataTask *)addRoom:(NSString *)domain toApplication:(NSString *)application inRoom:(NSString *)room completion:(XSCompletion)completion;
+- (NSURLSessionDataTask *)addRoom:(NSString *)room toApplication:(NSString *)application inDomain:(NSString *)domain completion:(XSCompletion)completion;
 
 @end

--- a/Classes/XSClient.m
+++ b/Classes/XSClient.m
@@ -46,16 +46,12 @@
 
 - (NSURLSessionDataTask *)getTokenForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room username:(NSString *)username secure:(BOOL)secure signalType:(XSSignalingType)type completion:(XSObjectCompletion)completion
 {
+    NSAssert(type == XSSignalingTypePeer, @"Signaling type %lu not supported.", (unsigned long)type);
+
     NSString *secureString = secure ? @"1" : @"0";
     NSDictionary *parameters = nil;
 
-    if (type == XSSignalingTypePeer) {
-        parameters = @{ @"domain": domain, @"application": application, @"room": room, @"username": username, @"secure": secureString };
-    }
-    else {
-        NSString *signalString = type == XSSignalingTypePublish ? @"publish" : @"subscribe";
-        parameters = @{ @"domain": domain, @"application": application, @"room": room, @"username": username, @"secure": secureString, @"type": signalString};
-    }
+    parameters = @{ @"domain": domain, @"application": application, @"room": room, @"username": username, @"secure": secureString };
 
     NSURLSessionDataTask *task = [self.request postPath:@"getToken" parameters:parameters completion:^(id response, NSError *error) {
         if (completion) {
@@ -109,12 +105,6 @@
     [task resume];
 
     return task;
-}
-
-- (NSURLSessionDataTask *)getSubscriptionsForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room completion:(XSObjectCompletion)completion
-{
-    NSDictionary *parameters = @{ @"domain": domain, @"application": application, @"room": room };
-    return [self basicGetRequestWithPath:@"subscribe" parameters:parameters objectCompletion:completion];
 }
 
 - (NSURLSessionDataTask *)listWebSocketServersWithCompletion:(XSObjectCompletion)completion

--- a/Classes/XSClient.m
+++ b/Classes/XSClient.m
@@ -35,44 +35,86 @@
 
 - (NSURLSessionDataTask *)getTokenForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room username:(NSString *)username secure:(BOOL)secure completion:(XSObjectCompletion)completion
 {
+    return [self getTokenForDomain:domain
+                       application:application
+                              room:room
+                          username:username
+                            secure:secure
+                        signalType:XSSignalingTypePeer
+                        completion:completion];
+}
+
+- (NSURLSessionDataTask *)getTokenForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room username:(NSString *)username secure:(BOOL)secure signalType:(XSSignalingType)type completion:(XSObjectCompletion)completion
+{
     NSString *secureString = secure ? @"1" : @"0";
-    NSDictionary *parameters = @{ @"domain": domain, @"application": application, @"room": room, @"username" : username, @"secure": secureString };
+    NSDictionary *parameters = nil;
+
+    if (type == XSSignalingTypePeer) {
+        parameters = @{ @"domain": domain, @"application": application, @"room": room, @"username": username, @"secure": secureString };
+    }
+    else {
+        NSString *signalString = type == XSSignalingTypePublish ? @"publish" : @"subscribe";
+        parameters = @{ @"domain": domain, @"application": application, @"room": room, @"username": username, @"secure": secureString, @"type": signalString};
+    }
 
     NSURLSessionDataTask *task = [self.request postPath:@"getToken" parameters:parameters completion:^(id response, NSError *error) {
         if (completion) {
             completion([response objectForKey:@"d"], error);
         }
     }];
-    
+
     [task resume];
-    
+
     return task;
 }
 
 - (NSURLSessionDataTask *)getIceServersForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room username:(NSString *)username secure:(BOOL)secure completion:(XSArrayCompletion)completion
 {
+    return [self getIceServersForDomain:domain
+                            application:application
+                                   room:room
+                               username:username
+                                 secure:secure
+                                timeout:0
+                             completion:completion];
+}
+
+- (NSURLSessionDataTask *)getIceServersForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room username:(NSString *)username secure:(BOOL)secure timeout:(NSTimeInterval)timeout completion:(XSArrayCompletion)completion
+{
     NSString *secureString = secure ? @"1" : @"0";
     NSDictionary *parameters = @{ @"domain": domain, @"application": application, @"room": room, @"username" : username, @"secure": secureString };
+
+    if (timeout > DBL_EPSILON) {
+        NSMutableDictionary *mParamters = [parameters mutableCopy];
+        mParamters[@"timeout"] = @(timeout);
+        parameters = mParamters;
+    }
 
     NSURLSessionDataTask *task = [self.request postPath:@"getIceServers" parameters:parameters completion:^(id response, NSError *error) {
         if (completion) {
             id servers = [response valueForKeyPath:@"d.iceServers"];
             NSMutableArray *serverObjects = [NSMutableArray array];
-            
+
             if (servers && servers != [NSNull null]) {
                 for (NSDictionary *serverJSON in servers) {
                     XSServer *server = [[XSServer alloc] initWithJSON:serverJSON];
                     [serverObjects addObject:server];
                 }
             }
-            
+
             completion([serverObjects copy], error);
         }
     }];
-    
+
     [task resume];
-    
+
     return task;
+}
+
+- (NSURLSessionDataTask *)getSubscriptionsForDomain:(NSString *)domain application:(NSString *)application room:(NSString *)room completion:(XSObjectCompletion)completion
+{
+    NSDictionary *parameters = @{ @"domain": domain, @"application": application, @"room": room };
+    return [self basicGetRequestWithPath:@"subscribe" parameters:parameters objectCompletion:completion];
 }
 
 - (NSURLSessionDataTask *)listWebSocketServersWithCompletion:(XSObjectCompletion)completion
@@ -90,7 +132,7 @@
 
 - (NSURLSessionDataTask *)listDomainsWithCompletion:(XSArrayCompletion)completion
 {
-    NSURLSessionDataTask *task = [self.request postPath:@"listDomains" parameters:nil completion:^(id response, NSError *error) {
+    NSURLSessionDataTask *task = [self.request getPath:@"domain" parameters:nil completion:^(id response, NSError *error) {
         if (completion) {
             completion([response objectForKey:@"d"], error);
         }
@@ -98,6 +140,21 @@
     
     [task resume];
     
+    return task;
+}
+
+- (NSURLSessionDataTask *)listApplicationsWithDomain:(NSString *)domain completion:(XSArrayCompletion)completion
+{
+    NSDictionary *parameters = @{ @"domain": domain };
+
+    NSURLSessionDataTask *task = [self.request getPath:@"application" parameters:parameters completion:^(id response, NSError *error) {
+        if (completion) {
+            completion([response objectForKey:@"d"], error);
+        }
+    }];
+
+    [task resume];
+
     return task;
 }
 
@@ -113,7 +170,7 @@
     return [self basicRequestWithPath:@"addApplication" parameters:parameters completion:completion];
 }
 
-- (NSURLSessionDataTask *)addRoom:(NSString *)domain toApplication:(NSString *)application inRoom:(NSString *)room completion:(XSCompletion)completion
+- (NSURLSessionDataTask *)addRoom:(NSString *)room toApplication:(NSString *)application inDomain:(NSString *)domain completion:(XSCompletion)completion
 {
     NSDictionary *parameters = @{ @"domain": domain, @"application": application, @"room": room };
     return [self basicRequestWithPath:@"addRoom" parameters:parameters completion:completion];
@@ -131,6 +188,19 @@
     
     [task resume];
     
+    return task;
+}
+
+- (NSURLSessionDataTask *)basicGetRequestWithPath:(NSString *)path parameters:(NSDictionary *)parameters objectCompletion:(XSObjectCompletion)completion
+{
+    NSURLSessionDataTask *task = [self.request getPath:path parameters:parameters completion:^(id response, NSError *error) {
+        if (completion) {
+            completion(response, error);
+        }
+    }];
+
+    [task resume];
+
     return task;
 }
 

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -2,17 +2,17 @@ PODS:
   - Expecta (1.0.0)
   - Keys (1.0.0)
   - Specta (1.0.1)
-  - XirSys (0.3)
+  - XirSys (0.4)
 
 DEPENDENCIES:
   - Expecta
-  - Keys (from `Pods/CocoaPodsKeys/`)
+  - Keys (from `Pods/CocoaPodsKeys`)
   - Specta
   - XirSys (from `../`)
 
 EXTERNAL SOURCES:
   Keys:
-    :path: Pods/CocoaPodsKeys/
+    :path: Pods/CocoaPodsKeys
   XirSys:
     :path: "../"
 
@@ -20,6 +20,6 @@ SPEC CHECKSUMS:
   Expecta: 32604574add2c46a36f8d2f716b6c5736eb75024
   Keys: 7d2ff6ff42f6903358267ce56e9392f83c31acfe
   Specta: 097be314a75de103703a3bf9a529dc1a398509d7
-  XirSys: 542a6e665b875fd01d519a09a11455b9fd42a556
+  XirSys: 0ea604c4b995f7005ba07a6ffd40675a93430b5d
 
-COCOAPODS: 0.37.1
+COCOAPODS: 0.37.2

--- a/XirSys.podspec
+++ b/XirSys.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "XirSys"
-  s.version          = "0.3"
+  s.version          = "0.4"
   s.summary          = "An Objective-C client for the XirSys API."
   s.homepage         = "https://github.com/samsymons/XirSys"
   s.license          = 'MIT'


### PR DESCRIPTION
Adds support for the XirSys v2 API endpoints.

* Timeout parameter for ice server calls
* Improved domain and room management
* Use GET in place of POST where appropriate
* New API base URL

TODO:

* [ ] Test new APIs and timeout argument